### PR TITLE
Refactor tank moving and collision handling methods

### DIFF
--- a/src/core/implementations/CBullet.h
+++ b/src/core/implementations/CBullet.h
@@ -4,8 +4,8 @@
 
 #include <QObject>
 
-#include "pod/Point.h"
 #include "interfaces/IBullet.h"
+#include "pod/Point.h"
 
 class CGameEngine;
 class CBullet : public QObject, public IBullet

--- a/src/core/implementations/CTank.h
+++ b/src/core/implementations/CTank.h
@@ -30,8 +30,7 @@ public:
 
     Q_INVOKABLE void shoot() override;
     Q_INVOKABLE void draw() override;
-    Q_INVOKABLE void extracted();
-    void move(MyEnum::Direction direction) override;
+    Q_INVOKABLE void move(MyEnum::Direction direction) override;
 
     int size() const;
 
@@ -40,6 +39,9 @@ signals:
 
 private:
     void onPositionChanged();
+    void handleObjectCollision(IDrawable* collide_object);
+    void moveInDirection(MyEnum::Direction direction);
+    void restorePosition();
 
     const int id_;
     TankData data_;

--- a/src/core/interfaces/IBase.h
+++ b/src/core/interfaces/IBase.h
@@ -41,3 +41,5 @@ public:
  * This macro is necessary for the IBase interface to be recognized by the Qt meta-object system and
  * to enable features such as dynamic_cast and qobject_cast.
 88 */
+
+Q_DECLARE_INTERFACE(IBase, "com.example.IBase")


### PR DESCRIPTION
The tank moving and collision handling methods have been refactored to improve readability and maintenance. Previously, the 'move' method in CTank class was cluttered and was responsible for multiple tasks i.e., moving the tank, checking for collisions, and handling them.

Now, the logic has been subdivided into smaller methods ('moveInDirection', 'handleObjectCollision', 'restorePosition') each with their distinct responsibility, adhering to the Single Responsibility Principle. This minor change improves the clarity of the code making it easier to interpret and manage. There is no change in the functionality of the program.

The order of import statements in CBullet was also corrected, and the Q_DECLARE_INTERFACE macro was added to the IBase class, ensuring compatibility with the Qt meta-object system.